### PR TITLE
Revamp ClusterWorkloadResourceMapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ spec:
       name: .name
       env: .env
       volumeMounts: .volumeMounts
-    volumes: .spec/template.spec.volumes
+    volumes: .spec.template.spec.volumes
 ```
 
 Note: This example is equivalent to not specifying a mapping or specifying an empty mapping.

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ A `MappingContainer` object **MUST** define a `path` entry is a string containin
 
 ## Restricted JSONPath
 
-> Note: only expression labels as 'Restricted JSONPath' **MUST** conform to this requirement. Other expressions **MAY** use the full JSONPath syntax.
+> Only expressions labeled as 'Restricted JSONPath' **MUST** conform to this requirement. Other expressions **MAY** use the full JSONPath syntax.
 
 A Restricted JSONPath is a subset of [JSONPath][jsonpath] expressions that **MUST NOT** use type and operators other than fields separated by the child operator.
 
@@ -561,7 +561,7 @@ spec:
     volumes: .spec/template.spec.volumes
 ```
 
-Note: this example is equivalent to not specifying a mapping, or specifying an empty mapping.
+Note: This example is equivalent to not specifying a mapping or specifying an empty mapping.
 
 ## Reconciler Implementation
 
@@ -569,7 +569,7 @@ A reconciler implementation **MUST** support mapping to PodSpec-able resources w
 
 If a `ServiceBinding` specifies `.spec.workload.containers` and a `MappingContainer` specifies a `name` expression, the resolved name **MUST** limit which containers in the workload are bound.
 
-A reconciler **MUST** create empty values at locations referenced by Restricted JSONPaths that do not exist on the workload resource. Values referenced by JSONPaths in both the `MappingTemplate` and `MappingContainer`s **MUST** be mutated by a `ServiceBinding` reconciler as if they were defined directly by a PodTemplateSpec. A reconciler **MUST** preserve fields on the workload resource that fall outside the specific fragments and types defined by the mapping.
+A reconciler **MUST** create empty values at locations referenced by [Restricted JSONPaths](#restricted-jsonpath) that do not exist on the workload resource. Values referenced by JSONPaths in both the `MappingTemplate` and `MappingContainer`s **MUST** be mutated by a `ServiceBinding` reconciler as if they were defined directly by a PodTemplateSpec. A reconciler **MUST** preserve fields on the workload resource that fall outside the specific fragments and types defined by the mapping.
 
 # Role-Based Access Control (RBAC)
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,11 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
   - [Direct Secret Reference Example Resource](#direct-secret-reference-example-resource)
 - [Workload Resource Mapping](#workload-resource-mapping)
   - [Resource Type Schema](#resource-type-schema-2)
-  - [Container-based Example Resource](#container-based-example-resource)
-  - [Element-based Example Resource](#element-based-example-resource)
+  - [Example Resource](#example-resource-3)
   - [PodSpec-able (Default) Example Resource](#podspec-able-default-example-resource)
   - [Reconciler Implementation](#reconciler-implementation-1)
 - [Role-Based Access Control (RBAC)](#role-based-access-control-rbac)
-  - [Example Resource](#example-resource-3)
+  - [Example Resource](#example-resource-4)
 
 ---
 
@@ -458,15 +457,18 @@ status:
 
 A Workload Resource Mapping describes how to apply [Service Binding](#service-binding) transformations to an [Workload Projection](#workload-projection).  It **MUST** be codified as a concrete resource type with API version `servicebinding.io/v1alpha3` and kind `ClusterWorkloadResourceMapping`.  For portability, the schema **MUST** comply to the exemplar CRD found [here][cwrm-crd].
 
-A Workload Resource Mapping **MUST** define its name using [CRD syntax][crd-syntax] (`<plural>.<group>`) for the resource that it defines a mapping for.  A Workload Resource Mapping **MUST** define a `.spec.versions` which is an array of `Version` objects.  A `Version` object must define a `version` entry that represents a version of the mapped resource.  The `version` entry **MAY** contain a `*` wildcard which indicates that this mapping should be used for any version that does not have a mapping explicitly defined for it.  A `Version` object **MAY** define `.containers`, as an array of strings containing [JSONPath][jsonpath], that describes the location of [`[]Container`][container] arrays in the target resource.  A `Version` object **MAY** define `.envs`, as an array of strings containing [JSONPath][jsonpath], that describes the location of [`[]EnvVar`][envvar] arrays in the target resource.  A `Version` object **MAY** define `.volumeMounts`, as an array of strings containing [JSONPath][jsonpath], that describes the location of [`[]VolumeMount`][volumemount] arrays in the target resource.  A `Version` object **MUST** define `.volumes`, as a string containing [JSONPath][jsonpath], that describes the location of [`[]Volume`][volume] arrays in the target resource.
+A Workload Resource Mapping **MUST** define its name using [CRD syntax][crd-syntax] (`<plural>.<group>`) for the resource that it defines a mapping for.  A Workload Resource Mapping **MUST** define a `.spec.versions` which is an array of `MappingTemplate` objects.
 
-If a Workload Resource Mapping defines `containers`, it **MUST NOT** define `.envs` and `.volumeMounts`.  If a Workload resources does not define `containers`, it **MUST** define `.envs` and `.volumeMounts`.
+A `MappingTemplate` object **MUST** define a `version` entry that represents a version of the mapped resource.  The `version` entry **MAY** contain a `*` wildcard which indicates that this mapping should be used for any version that does not have a mapping explicitly defined for it.  A `MappingTemplate` object **MAY** define `annotations`, as a string containing a [JSON Pointer][jsonpointer] that describes the location of a map of annotations in the target resource. If not specified, the default `annotations` pointer **MUST** be appropriate for mapping to a PodSpecable resource (`/spec/template/metadata/annotations`).  A `MappingTemplate` object **MAY** define `containers`, as an array of `MappingContainer` objects. If not specified, the default `MappingContainer` **MUST** be appropriate for mapping to a PodSpecable resource.  A `MappingTemplate` object **MAY** define `volumes`, as a string containing a [JSON Pointer][jsonpointer] that describes the location of [`[]Volume`][volume] arrays in the target resource. If not specified, the default `volumes` pointer **MUST** be appropriate for mapping to a PodSpecable resource (`/spec/template/spec/volumes`).
+
+A `MappingContainer` object **MUST** define a `path` entry is a string containing a [JSONPath][jsonpath] that references container like locations in the target resource. The following pointer references **MUST** be applied to each object matched by the path.  A `MappingTemplate` object **MAY** define `name`, as a string containing a [JSON Pointer][jsonpointer] that describes the location of a string in the target resource that names the container. A `MappingTemplate` object **MAY** define `env`, as a string containing a [JSON Pointer][jsonpointer] that describes the location of [`[]EnvVar`][envvar] array in the target resource. If not specified, the default `env` pointer **MUST** be appropriate for mapping within an actual Container object (`/env`). A `MappingTemplate` object **MAY** define `volumeMounts`, as a string containing a [JSON Pointer][jsonpointer] that describes the location of [`[]VolumeMount`][volumemount] array in the target resource. If not specified, the default `env` pointer **MUST** be appropriate for mapping within an actual Container object (`/volumeMounts`).
 
 [cwrm-crd]: servicebinding.io_clusterworkloadresourcemappings.yaml
 [container]: https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/container/
 [crd-syntax]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition
 [envvar]: https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/container/#environment-variables
-[jsonpath]: https://kubernetes.io/docs/reference/kubectl/jsonpath/
+[jsonpath]: http://goessner.net/articles/JsonPath/
+[jsonpointer]: https://datatracker.ietf.org/doc/html/rfc6901
 [volume]: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/volume
 [volumemount]: https://kubernetes.io/docs/reference/kubernetes-api/workloads-resources/container/#volumes
 
@@ -480,15 +482,17 @@ metadata:
   generation:           # int64, defined by the Kubernetes control plane
   ...
 spec:
-  versions:             # []Version
+  versions:             # []MappingTemplate
   - version:            # string
-    containers:         # []string, optional
-    envs:               # []string, optional
-    volumeMounts:       # []string, optional
-    volumes:            # string
+    containers:         # []MappingContainer, optional
+    - path:             # string (JSONPath)
+      name:             # string (JSON Pointer), optional
+      env:              # string (JSON Pointer), optional
+      volumeMounts:     # string (JSON Pointer), optional
+    volumes:            # string (JSON Pointer), optional
 ```
 
-## Container-based Example Resource
+## Example Resource
 
 ```yaml
 apiVersion: servicebinding.io/v1alpha3
@@ -499,28 +503,15 @@ spec:
   versions:
   - version: "*"
     containers:
-    - .spec.jobTemplate.spec.template.spec.containers
-    - .spec.jobTemplate.spec.template.spec.initContainers
-    volumes: .spec.jobTemplate.spec.template.spec.volumes
-```
-
-## Element-based Example Resource
-
-```yaml
-apiVersion: servicebinding.io/v1alpha3
-kind: ClusterWorkloadResourceMapping
-metadata:
- name:  cronjobs.batch
-spec:
-  versions:
-  - version: "*"
-    envs:
-    - .spec.jobTemplate.spec.template.spec.containers[*].env
-    - .spec.jobTemplate.spec.template.spec.initContainers[*].env
-    volumeMounts:
-    - .spec.jobTemplate.spec.template.spec.containers[*].volumeMounts
-    - .spec.jobTemplate.spec.template.spec.initContainers[*].volumeMounts
-    volumes: .spec.jobTemplate.spec.template.spec.volumes
+    - path: .spec.jobTemplate.spec.template.spec.containers[*]
+      name: /name
+      env: /env                     # this is the default value
+      volumeMounts: /volumeMounts   # this is the default value
+    - path: .spec.jobTemplate.spec.template.spec.initContainers[*]
+      name: /name
+      env: /env                     # this is the default value
+      volumeMounts: /volumeMounts   # this is the default value
+    volumes: /spec/jobTemplate/spec/template/spec/volumes
 ```
 
 ## PodSpec-able (Default) Example Resource
@@ -534,22 +525,26 @@ spec:
   versions:
   - version: "*"
     containers:
-    - .spec.template.spec.containers
-    - .spec.template.spec.initContainers
-    volumes: .spec.template.spec.volumes
+    - path: .spec.template.spec.containers[*]
+      name: /name
+      env: /env
+      volumeMounts: /volumeMounts
+    - path: .spec.template.spec.initContainers[*]
+      name: /name
+      env: /env
+      volumeMounts: /volumeMounts
+    volumes: /spec/template/spec/volumes
 ```
+
+Note: this example is equivalent to not specifying a mapping, or specifying an empty mapping.
 
 ## Reconciler Implementation
 
-A reconciler implementation **MUST** support mapping to PodSpec-able resources without defining a Workload Resource Mapping for those types.  If no Workload Resource Mapping exists for the `ServiceBinding` workload resource type and the workload resource is not PodSpec-able, the reconciliation **MUST** fail.
+A reconciler implementation **MUST** support mapping to PodSpec-able resources without defining a `ClusterWorkloadResourceMapping` for those types.
 
-If a `ClusterWorkloadResourceMapping` defines `containers`, the reconciler **MUST** first resolve a set of candidate locations in the workload resource addressed by the `ServiceBinding` using the `Container` type (`.envs`, `.volumeMounts`) for all available containers and then filter that collection by the `ServiceBinding` `.spec.workload.containers` filter before applying the appropriate modification.
+If a `ServiceBinding` specifies `.spec.workload.containers` and a `MappingContainer` specifies a `name` pointer, the resolved name **MUST** limit which containers in the workload are bound.
 
-If a `ClusterWorkloadResourceMapping` defines `.envs` and `.volumeMounts`, the reconciler **MUST** first resolve a set of candidate locations in the workload resource addressed by the `ServiceBinding` for all available containers and then filter that collection by the `ServiceBinding` `.spec.workload.containers` filter before applying the appropriate modification.
-
-If a `ServiceBinding` specifies `.spec.workload.containers` value, that value **MUST** be used to filter all entries in the `.containers` list.  If a `ServiceBinding` specifies a `.spec.workload.containers` value and `ClusterWorkloadResourceMapping` for the mapped type defines `.envs` and `.volumeMounts`, the reconciler **MUST** fail to reconcile.
-
-A reconciler **MUST** apply the appropriate modification to the workload resource addressed by the `ServiceBinding` as defined by `.volumes`.
+A reconciler **MUST** create empty values at locations referenced by JSON Pointers that do not exist on the workload resource. Values referenced by JSON Pointers in both the `MappingTemplate` and `MappingContainer`s **MUST** be mutated by a `ServiceBinding` reconciler as if they were defined directly by a PodTemplateSpec. A reconciler **MUST** preserve fields on the workload resource that fall outside the specific fragments and types defined by the mapping.
 
 # Role-Based Access Control (RBAC)
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
   - [Restricted JSONPath](#restricted-jsonpath)
   - [Resource Type Schema](#resource-type-schema-2)
   - [Example Resource](#example-resource-3)
-  - [PodSpec-able (Default) Example Resource](#podspec-able-default-example-resource)
-  - [Reconciler Implementation](#reconciler-implementation-1)
+  - [PodSpecable (Default) Example Resource](#podspecable-default-example-resource)
+  - [Runtime Behavior](#runtime-behavior)
 - [Role-Based Access Control (RBAC)](#role-based-access-control-rbac)
   - [Example Resource](#example-resource-4)
 
@@ -508,13 +508,13 @@ metadata:
   ...
 spec:
   versions:             # []MappingTemplate
-  - version:            # string
-    containers:         # []MappingContainer, optional
-    - path:             # string (JSONPath)
-      name:             # string (Restricted JSONPath), optional
-      env:              # string (Restricted JSONPath), optional
-      volumeMounts:     # string (Restricted JSONPath), optional
-    volumes:            # string (Restricted JSONPath), optional
+  - version:              # string
+    containers:           # []MappingContainer, optional
+    - path:                 # string (JSONPath)
+      name:                 # string (Restricted JSONPath), optional
+      env:                  # string (Restricted JSONPath), optional
+      volumeMounts:         # string (Restricted JSONPath), optional
+    volumes:              # string (Restricted JSONPath), optional
 ```
 
 ## Example Resource
@@ -529,7 +529,7 @@ spec:
   - version: "*"
     containers:
     - path: .spec.jobTemplate.spec.template.spec.containers[*]
-g      name: .name
+      name: .name
       env: .env                     # this is the default value
       volumeMounts: .volumeMounts   # this is the default value
     - path: .spec.jobTemplate.spec.template.spec.initContainers[*]
@@ -539,7 +539,7 @@ g      name: .name
     volumes: .spec.jobTemplate.spec.template.spec.volumes
 ```
 
-## PodSpec-able (Default) Example Resource
+## PodSpecable (Default) Example Resource
 
 ```yaml
 apiVersion: servicebinding.io/v1alpha3
@@ -563,13 +563,13 @@ spec:
 
 Note: This example is equivalent to not specifying a mapping or specifying an empty mapping.
 
-## Reconciler Implementation
+## Runtime Behavior
 
-A reconciler implementation **MUST** support mapping to PodSpec-able resources without defining a `ClusterWorkloadResourceMapping` for those types.
+When a `ClusterWorkloadResourceMapping` is defined in the cluster matching a workload resource it **MUST** be used to map the binding that type. If no mapping is available for the type, the implementation **MUST** treat the workload resource as a PodSpecable type.
 
-If a `ServiceBinding` specifies `.spec.workload.containers` and a `MappingContainer` specifies a `name` expression, the resolved name **MUST** limit which containers in the workload are bound.
+If a `ServiceBinding` specifies `.spec.workload.containers` and a `MappingContainer` specifies a `name` expression, the resolved name **MUST** limit which containers in the workload are bound. If either key is not defined, the container **SHOULD** be bound.
 
-A reconciler **MUST** create empty values at locations referenced by [Restricted JSONPaths](#restricted-jsonpath) that do not exist on the workload resource. Values referenced by JSONPaths in both the `MappingTemplate` and `MappingContainer`s **MUST** be mutated by a `ServiceBinding` reconciler as if they were defined directly by a PodTemplateSpec. A reconciler **MUST** preserve fields on the workload resource that fall outside the specific fragments and types defined by the mapping.
+An implementation **MUST** create empty values at locations referenced by [Restricted JSONPaths](#restricted-jsonpath) that do not exist on the workload resource. Values referenced by JSONPaths in both the `MappingTemplate` and `MappingContainer`s **MUST** be mutated by a `ServiceBinding` reconciler as if they were defined directly by a PodTemplateSpec. A reconciler **MUST** preserve fields on the workload resource that fall outside the specific fragments and types defined by the mapping.
 
 # Role-Based Access Control (RBAC)
 

--- a/internal/servicebinding.io/v1alpha3/cluster_workload_resource_mapping.go
+++ b/internal/servicebinding.io/v1alpha3/cluster_workload_resource_mapping.go
@@ -23,15 +23,15 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type ClusterWorkloadResourceMappingTemplate struct {
 	// Version is the version of the workload resource that this mapping is for.
 	Version string `json:"version"`
-	// Annotations is a JSON Pointer that references the annotations map within the workload resource. These
+	// Annotations is a Restricted JSONPath that references the annotations map within the workload resource. These
 	// annotations must end up in the resulting Pod, and are generally not the workload resource's annotations.
-	// Defaults to `/spec/template/metadata/annotations`.
+	// Defaults to `.spec.template.metadata.annotations`.
 	Annotations string `json:"annotations"`
 	// Containers is the collection of mappings to container-like fragments of the workload resource. Defaults to
 	// mappings appropriate for a PodSpecable resource.
 	Containers []ClusterWorkloadResourceMappingContainer `json:"containers,omitempty"`
-	// Volumes is a JSON Pointer that references the slice of volumes within the workload resource. Defaults to
-	// `/spec/template/spec/volumes`.
+	// Volumes is a Restricted JSONPath that references the slice of volumes within the workload resource. Defaults to
+	// `.spec.template.spec.volumes`.
 	Volumes string `json:"volumes"`
 }
 
@@ -39,21 +39,21 @@ type ClusterWorkloadResourceMappingTemplate struct {
 // to a Container-like structure.
 //
 // Each mapping defines exactly one path that may match multiple container-like fragments within the workload
-// resource. For each object matching the path the name, env and volumeMounts pointers are resolved to find those
+// resource. For each object matching the path the name, env and volumeMounts expressions are resolved to find those
 // structures.
 type ClusterWorkloadResourceMappingContainer struct {
 	// Path is the JSONPath within the workload resource that matches an existing fragment that is container-like.
 	Path string `json:"path"`
-	// Name is a JSON Pointer that references the name of the container with the container-like workload resource
+	// Name is a Restricted JSONPath that references the name of the container with the container-like workload resource
 	// fragment. If not defined, container name filtering is ignored.
 	Name string `json:"name,omitempty"`
-	// Env is a JSON Pointer that references the slice of environment variables for the container with the
+	// Env is a Restricted JSONPath that references the slice of environment variables for the container with the
 	// container-like workload resource fragment. The referenced location is created if it does not exist. Defaults
-	// to `/envs`.
+	// to `.envs`.
 	Env string `json:"env,omitempty"`
-	// VolumeMounts is a JSON Pointer that references the slice of volume mounts for the container with the
+	// VolumeMounts is a Restricted JSONPath that references the slice of volume mounts for the container with the
 	// container-like workload resource fragment. The referenced location is created if it does not exist. Defaults
-	// to `/volumeMounts`.
+	// to `.volumeMounts`.
 	VolumeMounts string `json:"volumeMounts,omitempty"`
 }
 

--- a/internal/servicebinding.io/v1alpha3/cluster_workload_resource_mapping.go
+++ b/internal/servicebinding.io/v1alpha3/cluster_workload_resource_mapping.go
@@ -18,24 +18,49 @@ package v1alpha3
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// ClusterWorkloadResourceMappingVersion defines the mapping for a specific version of a workload resource.
-type ClusterWorkloadResourceMappingVersion struct {
+// ClusterWorkloadResourceMappingTemplate defines the mapping for a specific version of an workload resource to a
+// logical PodTemplateSpec-like structure.
+type ClusterWorkloadResourceMappingTemplate struct {
 	// Version is the version of the workload resource that this mapping is for.
 	Version string `json:"version"`
-	// Containers is the collection of JSONPaths that container configuration may be written to.
-	Containers []string `json:"containers,omitempty"`
-	// Envs is the collection of JSONPaths that env configuration may be written to.
-	Envs []string `json:"envs,omitempty"`
-	// VolumeMounts is the collection of JSONPaths that volume mount configuration may be written to.
-	VolumeMounts []string `json:"volumeMounts,omitempty"`
-	// Volumes is the JSONPath that volume configuration must be written to.
+	// Annotations is a JSON Pointer that references the annotations map within the workload resource. These
+	// annotations must end up in the resulting Pod, and are generally not the workload resource's annotations.
+	// Defaults to `/spec/template/metadata/annotations`.
+	Annotations string `json:"annotations"`
+	// Containers is the collection of mappings to container-like fragments of the workload resource. Defaults to
+	// mappings appropriate for a PodSpecable resource.
+	Containers []ClusterWorkloadResourceMappingContainer `json:"containers,omitempty"`
+	// Volumes is a JSON Pointer that references the slice of volumes within the workload resource. Defaults to
+	// `/spec/template/spec/volumes`.
 	Volumes string `json:"volumes"`
+}
+
+// ClusterWorkloadResourceMappingContainer defines the mapping for a specific fragment of an workload resource
+// to a Container-like structure.
+//
+// Each mapping defines exactly one path that may match multiple container-like fragments within the workload
+// resource. For each object matching the path the name, env and volumeMounts pointers are resolved to find those
+// structures.
+type ClusterWorkloadResourceMappingContainer struct {
+	// Path is the JSONPath within the workload resource that matches an existing fragment that is container-like.
+	Path string `json:"path"`
+	// Name is a JSON Pointer that references the name of the container with the container-like workload resource
+	// fragment. If not defined, container name filtering is ignored.
+	Name string `json:"name,omitempty"`
+	// Env is a JSON Pointer that references the slice of environment variables for the container with the
+	// container-like workload resource fragment. The referenced location is created if it does not exist. Defaults
+	// to `/envs`.
+	Env string `json:"env,omitempty"`
+	// VolumeMounts is a JSON Pointer that references the slice of volume mounts for the container with the
+	// container-like workload resource fragment. The referenced location is created if it does not exist. Defaults
+	// to `/volumeMounts`.
+	VolumeMounts string `json:"volumeMounts,omitempty"`
 }
 
 // ClusterWorkloadResourceMappingSpec defines the desired state of ClusterWorkloadResourceMapping
 type ClusterWorkloadResourceMappingSpec struct {
 	// Versions is the collection of versions for a given resource, with mappings.
-	Versions []ClusterWorkloadResourceMappingVersion `json:"versions,omitempty"`
+	Versions []ClusterWorkloadResourceMappingTemplate `json:"versions,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/servicebinding.io_clusterworkloadresourcemappings.yaml
+++ b/servicebinding.io_clusterworkloadresourcemappings.yaml
@@ -39,30 +39,40 @@ spec:
               versions:
                 description: Versions is the collection of versions for a given resource, with mappings.
                 items:
-                  description: ClusterWorkloadResourceMappingVersion defines the mapping for a specific version of a workload resource.
+                  description: ClusterWorkloadResourceMappingTemplate defines the mapping for a specific version of an workload resource to a logical PodTemplateSpec-like structure.
                   properties:
+                    annotations:
+                      description: Annotations is a JSON Pointer that references the annotations map within the workload resource. These annotations must end up in the resulting Pod, and are generally not the workload resource's annotations. Defaults to `/spec/template/metadata/annotations`.
+                      type: string
                     containers:
-                      description: Containers is the collection of JSONPaths that container configuration may be written to.
+                      description: Containers is the collection of mappings to container-like fragments of the workload resource. Defaults to mappings appropriate for a PodSpecable resource.
                       items:
-                        type: string
-                      type: array
-                    envs:
-                      description: Envs is the collection of JSONPaths that env configuration may be written to.
-                      items:
-                        type: string
+                        description: "ClusterWorkloadResourceMappingContainer defines the mapping for a specific fragment of an workload resource to a Container-like structure. \n Each mapping defines exactly one path that may match multiple container-like fragments within the workload resource. For each object matching the path the name, env and volumeMounts pointers are resolved to find those structures."
+                        properties:
+                          env:
+                            description: Env is a JSON Pointer that references the slice of environment variables for the container with the container-like workload resource fragment. The referenced location is created if it does not exist. Defaults to `/envs`.
+                            type: string
+                          name:
+                            description: Name is a JSON Pointer that references the name of the container with the container-like workload resource fragment. If not defined, container name filtering is ignored.
+                            type: string
+                          path:
+                            description: Path is the JSONPath within the workload resource that matches an existing fragment that is container-like.
+                            type: string
+                          volumeMounts:
+                            description: VolumeMounts is a JSON Pointer that references the slice of volume mounts for the container with the container-like workload resource fragment. The referenced location is created if it does not exist. Defaults to `/volumeMounts`.
+                            type: string
+                        required:
+                        - path
+                        type: object
                       type: array
                     version:
                       description: Version is the version of the workload resource that this mapping is for.
                       type: string
-                    volumeMounts:
-                      description: VolumeMounts is the collection of JSONPaths that volume mount configuration may be written to.
-                      items:
-                        type: string
-                      type: array
                     volumes:
-                      description: Volumes is the JSONPath that volume configuration must be written to.
+                      description: Volumes is a JSON Pointer that references the slice of volumes within the workload resource. Defaults to `/spec/template/spec/volumes`.
                       type: string
                   required:
+                  - annotations
                   - version
                   - volumes
                   type: object

--- a/servicebinding.io_clusterworkloadresourcemappings.yaml
+++ b/servicebinding.io_clusterworkloadresourcemappings.yaml
@@ -42,24 +42,24 @@ spec:
                   description: ClusterWorkloadResourceMappingTemplate defines the mapping for a specific version of an workload resource to a logical PodTemplateSpec-like structure.
                   properties:
                     annotations:
-                      description: Annotations is a JSON Pointer that references the annotations map within the workload resource. These annotations must end up in the resulting Pod, and are generally not the workload resource's annotations. Defaults to `/spec/template/metadata/annotations`.
+                      description: Annotations is a Restricted JSONPath that references the annotations map within the workload resource. These annotations must end up in the resulting Pod, and are generally not the workload resource's annotations. Defaults to `.spec.template.metadata.annotations`.
                       type: string
                     containers:
                       description: Containers is the collection of mappings to container-like fragments of the workload resource. Defaults to mappings appropriate for a PodSpecable resource.
                       items:
-                        description: "ClusterWorkloadResourceMappingContainer defines the mapping for a specific fragment of an workload resource to a Container-like structure. \n Each mapping defines exactly one path that may match multiple container-like fragments within the workload resource. For each object matching the path the name, env and volumeMounts pointers are resolved to find those structures."
+                        description: "ClusterWorkloadResourceMappingContainer defines the mapping for a specific fragment of an workload resource to a Container-like structure. \n Each mapping defines exactly one path that may match multiple container-like fragments within the workload resource. For each object matching the path the name, env and volumeMounts expressions are resolved to find those structures."
                         properties:
                           env:
-                            description: Env is a JSON Pointer that references the slice of environment variables for the container with the container-like workload resource fragment. The referenced location is created if it does not exist. Defaults to `/envs`.
+                            description: Env is a Restricted JSONPath that references the slice of environment variables for the container with the container-like workload resource fragment. The referenced location is created if it does not exist. Defaults to `.envs`.
                             type: string
                           name:
-                            description: Name is a JSON Pointer that references the name of the container with the container-like workload resource fragment. If not defined, container name filtering is ignored.
+                            description: Name is a Restricted JSONPath that references the name of the container with the container-like workload resource fragment. If not defined, container name filtering is ignored.
                             type: string
                           path:
                             description: Path is the JSONPath within the workload resource that matches an existing fragment that is container-like.
                             type: string
                           volumeMounts:
-                            description: VolumeMounts is a JSON Pointer that references the slice of volume mounts for the container with the container-like workload resource fragment. The referenced location is created if it does not exist. Defaults to `/volumeMounts`.
+                            description: VolumeMounts is a Restricted JSONPath that references the slice of volume mounts for the container with the container-like workload resource fragment. The referenced location is created if it does not exist. Defaults to `.volumeMounts`.
                             type: string
                         required:
                         - path
@@ -69,7 +69,7 @@ spec:
                       description: Version is the version of the workload resource that this mapping is for.
                       type: string
                     volumes:
-                      description: Volumes is a JSON Pointer that references the slice of volumes within the workload resource. Defaults to `/spec/template/spec/volumes`.
+                      description: Volumes is a Restricted JSONPath that references the slice of volumes within the workload resource. Defaults to `.spec.template.spec.volumes`.
                       type: string
                   required:
                   - annotations


### PR DESCRIPTION
The mapping structure now more closely aligns with the PodTemplateSpec
shape. It uses a JSONPath query for container-like structures that may
occur anywhere within the target workload resource, and JSON Pointer
references to specific structures either from the root of the object or
relative to a container discovered by a path query.

The high level approach is described in https://github.com/k8s-service-bindings/spec/issues/177#issuecomment-884935203 and with proof of concept code in https://github.com/k8s-service-bindings/spec/issues/177#issuecomment-887538101

Resolves #177 #173 #189 