### PR TITLE
Publish Service Binding APIs as v1beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ rules:
 
 # Service Binding
 
-A Service Binding describes the connection between a [Provisioned Service](#provisioned-service) and a [workload projection](#workload-projection).  It **MUST** be codified as a concrete resource type with API version `servicebinding.io/v1alpha3` and kind `ServiceBinding`.  Multiple `ServiceBinding`s can refer to the same service.  Multiple `ServiceBinding`s can refer to the same workload.  For portability, the schema **MUST** comply to the exemplar CRD found [here][sb-crd].
+A Service Binding describes the connection between a [Provisioned Service](#provisioned-service) and a [workload projection](#workload-projection).  It **MUST** be codified as a concrete resource type with API version `servicebinding.io/v1beta1` and kind `ServiceBinding`.  Multiple `ServiceBinding`s can refer to the same service.  Multiple `ServiceBinding`s can refer to the same workload.  For portability, the schema **MUST** comply to the exemplar CRD found [here][sb-crd].
 
 Restricting service binding to resources within the same namespace is strongly **RECOMMENDED**.  Implementations that choose to support cross-namespace service binding **SHOULD** provide a security model that prevents attacks like privilege escalation and secret enumeration, as well as a deterministic way to declare target namespaces.
 
@@ -272,7 +272,7 @@ When updating the status of the `ServiceBinding`, the controller **MUST** set th
 ## Resource Type Schema
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name:                 # string
@@ -309,7 +309,7 @@ status:
 ## Minimal Example Resource
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: account-service
@@ -336,7 +336,7 @@ status:
 ## Label Selector Example Resource
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: online-banking-frontend-to-account-service
@@ -368,7 +368,7 @@ status:
 ## Environment Variables Example Resource
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: account-service
@@ -429,7 +429,7 @@ When the `.spec.service.kind` attribute is `Secret` and `.spec.service.apiVersio
 ## Direct Secret Reference Example Resource
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: account-service
@@ -458,7 +458,7 @@ status:
 
 # Workload Resource Mapping
 
-A workload resource mapping describes how to apply [service binding](#service-binding) transformations to a [workload projection](#workload-projection).  It **MUST** be codified as a concrete resource type (cluster scoped resource) with API version `servicebinding.io/v1alpha3` and kind `ClusterWorkloadResourceMapping`.  For portability, the schema **MUST** comply to the exemplar CRD found [here][cwrm-crd].
+A workload resource mapping describes how to apply [service binding](#service-binding) transformations to a [workload projection](#workload-projection).  It **MUST** be codified as a concrete resource type (cluster scoped resource) with API version `servicebinding.io/v1beta1` and kind `ClusterWorkloadResourceMapping`.  For portability, the schema **MUST** comply to the exemplar CRD found [here][cwrm-crd].
 
 A workload resource mapping **MUST** define its name using [CRD syntax][crd-syntax] (`<plural>.<group>`) for the resource that it defines a mapping for.  A workload resource mapping **MUST** define a `.spec.versions` which is an array of `MappingTemplate` objects.
 
@@ -502,7 +502,7 @@ All other types and operators are disallowed, including but not limited to:
 ## Resource Type Schema
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ClusterWorkloadResourceMapping
 metadata:
   name:                 # string
@@ -523,7 +523,7 @@ spec:
 ## Example Resource
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ClusterWorkloadResourceMapping
 metadata:
  name:  cronjobs.batch
@@ -546,7 +546,7 @@ spec:
 ## `PodSpec`-able (Default) Example Resource
 
 ```yaml
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ClusterWorkloadResourceMapping
 metadata:
   name: deployments.apps

--- a/internal/servicebinding.io/v1beta1/cluster_workload_resource_mapping.go
+++ b/internal/servicebinding.io/v1beta1/cluster_workload_resource_mapping.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v1alpha3
+package v1beta1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/internal/servicebinding.io/v1beta1/group_version.go
+++ b/internal/servicebinding.io/v1beta1/group_version.go
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-// Package v1alpha3 contains API Schema definitions for the service v1alpha3 API group
+// Package v1beta1 contains API Schema definitions for the service v1beta1 API group
 // +kubebuilder:object:generate=true
 // +groupName=servicebinding.io
-package v1alpha3
+package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "servicebinding.io", Version: "v1alpha3"}
+	GroupVersion = schema.GroupVersion{Group: "servicebinding.io", Version: "v1beta1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/internal/servicebinding.io/v1beta1/service_binding.go
+++ b/internal/servicebinding.io/v1beta1/service_binding.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package v1alpha3
+package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/servicebinding.io_clusterworkloadresourcemappings.yaml
+++ b/servicebinding.io_clusterworkloadresourcemappings.yaml
@@ -20,7 +20,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha3
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ClusterWorkloadResourceMapping is the Schema for the clusterworkloadresourcemappings API

--- a/servicebinding.io_servicebindings.yaml
+++ b/servicebinding.io_servicebindings.yaml
@@ -26,7 +26,7 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    name: v1alpha3
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ServiceBinding is the Schema for the servicebindings API


### PR DESCRIPTION
An implementation may choose to retain support for the v1alpha* APIs.

Resolves #204 