### PR TITLE
Define ServiceAvailable condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Participation in the Service Binding community is governed by the [Contributor C
   - [Environment Variables Example Resource](#environment-variables-example-resource)
   - [Reconciler Implementation](#reconciler-implementation)
     - [Ready Condition Status](#ready-condition-status)
+    - [ServiceAvailable Condition Status](#serviceavailable-condition-status)
 - [Direct Secret Reference](#direct-secret-reference)
   - [Direct Secret Reference Example Resource](#direct-secret-reference-example-resource)
 - [Workload Resource Mapping](#workload-resource-mapping)
@@ -413,6 +414,10 @@ The `ServiceBinding` status **MUST** be updated for the result of an error when 
 ### Ready Condition Status
 
 If the service binding is completed successfully, the `Ready` condition status **MUST** be set to `True`.  If the service binding cannot be completed, including cases where the service or workload resource are not found or do not conform to the specification requirements, the `Ready` condition status **MUST** be set to `False`.  If the `Ready` condition status is neither actively `True` nor `False` it **SHOULD** be set to `Unknown`.
+
+### ServiceAvailable Condition Status
+
+If the referenced Provisioned Service exists and exposes a binding secret, the `ServiceAvailable` condition status **MUST** be set to `True`.  If the referenced Provisioned Service either does not exist, or it cannot be determined if the resource exists, the `ServiceAvailable` condition status **MUST** be set to `False` with a meaningful message.  If the `ServiceAvailable` condition status is neither actively `True` nor `False` it **SHOULD** be set to `Unknown`.
 
 # Direct Secret Reference
 


### PR DESCRIPTION
Add a `ServiceAvailable` condition to the `ServiceBinding` status.
Logically, the behavior covered by the `ServiceAvailable` condition is a
subset of the existing `Ready` condition. The behavior of the `Ready`
condition is unchanged.

The status is `True` when the referenced Provisioned Service is resolved
and exposes a binding secret. The status is `False` if the Provisioned
Service cannot be resolved, either because it does not exist, or is not
visible to the implementation. The status is `Unknown` when the
referenced Provisioned Service is resolved, but does not expose a
binding secret.

When managing the rollout of resources that include a service, binding
and workload it can be difficult today to observe each resource to know
when there is a problem that requires remediation.
- It is common (and often desirable) for a workload to crash if a
  required service is not available.
- The `Ready` condition will be `False` if the workload does not exist

The above cases make it difficult for tools to observe the health of
either resource during the rollout, while the resource will eventually
settle on a healthy status, a circuit breaker could flip in the interim
that reverts the rollout. With a new `ServiceAvailable` condition we can
stagger the rollout of the resource to upsert the service and binding,
wait for `ServiceAvailable` to become `True` and then upsert the
workload.

Additionally, if the workload is immutable (like a Job), the creation of
the workload must be held until the service is known to exist. The
`ServiceAvailable` condition becoming `True` can signal that it's ok to
create the workload. If the workload is created before the service is
available, the ServiceBinding won't be able to complete the binding.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>