### PR TITLE
go: mark annotations and volumes as optional

### DIFF
--- a/internal/servicebinding.io/v1beta1/cluster_workload_resource_mapping.go
+++ b/internal/servicebinding.io/v1beta1/cluster_workload_resource_mapping.go
@@ -26,13 +26,13 @@ type ClusterWorkloadResourceMappingTemplate struct {
 	// Annotations is a Restricted JSONPath that references the annotations map within the workload resource. These
 	// annotations must end up in the resulting Pod, and are generally not the workload resource's annotations.
 	// Defaults to `.spec.template.metadata.annotations`.
-	Annotations string `json:"annotations"`
+	Annotations string `json:"annotations,omitempty"`
 	// Containers is the collection of mappings to container-like fragments of the workload resource. Defaults to
 	// mappings appropriate for a PodSpecable resource.
 	Containers []ClusterWorkloadResourceMappingContainer `json:"containers,omitempty"`
 	// Volumes is a Restricted JSONPath that references the slice of volumes within the workload resource. Defaults to
 	// `.spec.template.spec.volumes`.
-	Volumes string `json:"volumes"`
+	Volumes string `json:"volumes,omitempty"`
 }
 
 // ClusterWorkloadResourceMappingContainer defines the mapping for a specific fragment of an workload resource

--- a/servicebinding.io_clusterworkloadresourcemappings.yaml
+++ b/servicebinding.io_clusterworkloadresourcemappings.yaml
@@ -72,9 +72,7 @@ spec:
                       description: Volumes is a Restricted JSONPath that references the slice of volumes within the workload resource. Defaults to `.spec.template.spec.volumes`.
                       type: string
                   required:
-                  - annotations
                   - version
-                  - volumes
                   type: object
                 type: array
             type: object


### PR DESCRIPTION
The latest version of the specification (v1) allows for the `.spec.versions[*].annotations` and `.spec.versions[*].volumes` fields of `ClusterWorkloadResourceMapping` resources to be optional.  However, the exemplar go data structures require their existance when serializing/deserializing.

Update the canonical definition of `ClusterWorkloadResourceMapping` structs to be accurate.

Signed-off-by: Andy Sadler <ansadler@redhat.com>