### PR TITLE
Clarify that non-binding directories may be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ rules:
 
 A projected binding **MUST** be volume mounted into a container at `$SERVICE_BINDING_ROOT/<binding-name>` with directory names matching the name of the binding.  Binding names **MUST** match `[a-z0-9\-\.]{1,253}`.  The `$SERVICE_BINDING_ROOT` environment variable **MUST** be declared and can point to any valid file system location.
 
-The projected binding **MUST** contain a `type` entry with a value that identifies the abstract classification of the binding.  It is **RECOMMENDED** that the projected binding also contain a `provider` entry with a value that identifies the provider of the binding.  The projected binding data **MAY** contain any other entry.
+The projected binding **MUST** contain a `type` entry with a value that identifies the abstract classification of the binding.  It is **RECOMMENDED** that the projected binding also contain a `provider` entry with a value that identifies the provider of the binding.  The projected binding data **MAY** contain any other entry. Directories under `$SERVICE_BINDING_ROOT` that do not contain a `type` entry **SHOULD** be ignored by the workload process at runtime.
 
 The name of a binding entry file name **SHOULD** match `[a-z0-9\-\.]{1,253}`.  The contents of a binding entry may be anything representable as bytes on the file system including, but not limited to, a literal string value (e.g. `db-password`), a language-specific binary (e.g. a Java `KeyStore` with a private key and X.509 certificate), or an indirect pointer to another system for value resolution (e.g. `vault://production-database/password`).
 


### PR DESCRIPTION
A directory under `$SERVICE_BINDING_ROOT` that does not have a `type`
entry is not a complete binding and should be ignored. Even when that
directly is created as a direct result of a ServiceBinding resource.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>