### PR TITLE
Update copyright holder

### DIFF
--- a/internal/Makefile
+++ b/internal/Makefile
@@ -1,4 +1,4 @@
-#  Copyright 2020 Original Authors
+#  Copyright 2020 the original author or authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/internal/servicebinding.io/v1beta1/cluster_workload_resource_mapping.go
+++ b/internal/servicebinding.io/v1beta1/cluster_workload_resource_mapping.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Original Authors
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/servicebinding.io/v1beta1/group_version.go
+++ b/internal/servicebinding.io/v1beta1/group_version.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Original Authors
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/servicebinding.io/v1beta1/service_binding.go
+++ b/internal/servicebinding.io/v1beta1/service_binding.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Original Authors
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Original Authors
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
It's now consistently "the original author or authors."

Signed-off-by: Scott Andrews <andrewssc@vmware.com>