### PR TITLE
Clarify binding name collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ The name of a binding entry file name **SHOULD** match `[a-z0-9\-\.]{1,253}`.  T
 
 The collection of files within the directory **MAY** change during the lifetime of the container or between container launches.
 
+Users **SHOULD** ensure each binding has a unique name.  The behavior for name collisions is undefined.  Implementations **MAY** attempt a good faith check for collisions to provide a meaningful error message.
+
 ## Example Directory Structure
 
 ```plain


### PR DESCRIPTION
Because service bindings are inherently decentralized, there is no way to universally detect a name collision. Users are encouraged to avoid colliding names as the behavior is undefined by the spec. Implementations may check for known collisions to display a more meaningful to the user, but detection cannot be guaranteed as it's at best a good faith attempt.